### PR TITLE
Fix navigation links and remove unused loader

### DIFF
--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -13,10 +13,10 @@
         </div>
         <div class="flex flex-1 justify-end gap-8">
           <div class="flex items-center gap-9">
-            <a class="text-white text-sm font-medium leading-normal" href="#">Overview</a>
-            <a class="text-white text-sm font-medium leading-normal" href="#">Features</a>
-            <a class="text-white text-sm font-medium leading-normal" href="#">Pricing</a>
-            <a class="text-white text-sm font-medium leading-normal" href="#">Contact</a>
+            <router-link class="text-white text-sm font-medium leading-normal" :to="{name:'home'}">Overview</router-link>
+            <router-link class="text-white text-sm font-medium leading-normal" :to="{name:'timeline'}">Features</router-link>
+            <router-link class="text-white text-sm font-medium leading-normal" :to="{name:'help'}">Help</router-link>
+            <router-link class="text-white text-sm font-medium leading-normal" :to="{name:'license'}">License</router-link>
           </div>
           <button class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-[#0b80ee] text-white text-sm font-bold leading-normal tracking-[0.015em]" @click="upload">
             <span class="truncate">Upload Data</span>

--- a/src/views/Labeler.vue
+++ b/src/views/Labeler.vue
@@ -165,7 +165,6 @@ export default {
       plottingApp.csvData = this.csvData;
       plottingApp.seriesList = this.seriesList;
       plottingApp.labelList = this.labelList.sort();
-      $("#maindiv").append("<div class=\"loader\"></div>");
 
       // populate selectors
       this.handleSelector();
@@ -540,23 +539,6 @@ svg {
   shape-rendering: crispEdges;
 }
 
-.loader {
-  position: fixed;
-  left: 45%;
-  right: 25%;
-  top: 25%;
-  border: 16px solid #f3f3f3; /* Light grey */
-  border-top: 16px solid #3498db; /* Blue */
-  border-radius: 50%;
-  width: 120px;
-  height: 120px;
-  animation: spin 2s linear infinite;
-}
-
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
-}
 
 .chartText {
   font-family: 'Avenir', Helvetica, Arial, sans-serif;


### PR DESCRIPTION
This pull request includes updates to navigation links in `Index.vue` and removes unused code related to a loading spinner in `Labeler.vue`. The most important changes involve replacing static anchor tags with `router-link` components for improved navigation and cleaning up unused styles and DOM manipulation code.

### Navigation Updates:
* [`src/views/Index.vue`](diffhunk://#diff-8901ba02f06b6b8b828d7592c7b5ec4c31cddd62d7d28bb592990a090b5c9ecdL16-R19): Replaced static `<a>` tags with Vue `router-link` components to enable dynamic routing for navigation links such as "Overview," "Features," "Help," and "License."

### Code Cleanup:
* [`src/views/Labeler.vue`](diffhunk://#diff-9a877251f036899da8e3949385424fc7ebf5a49a754863ce3088d79789d8d0ecL168): Removed jQuery-based DOM manipulation that appended a loader element (`$(".loader")`) to the `#maindiv` container.
* [`src/views/Labeler.vue`](diffhunk://#diff-9a877251f036899da8e3949385424fc7ebf5a49a754863ce3088d79789d8d0ecL543-L559): Deleted CSS styles and keyframes related to the `.loader` class, which were no longer in use.