### PR TITLE
Fix upload nav link and restrict labeler styles

### DIFF
--- a/src/components/BaseNavbar.vue
+++ b/src/components/BaseNavbar.vue
@@ -6,6 +6,7 @@
         <router-link class="nav-link" v-bind:to="'/help'">Help</router-link>
         <router-link class="nav-link" v-bind:to="'/license'">License</router-link>
         <router-link class="nav-link" v-bind:to="'/timeline'">Demo</router-link>
+        <router-link class="nav-link" :to="{ name: 'labeler' }">Upload Data</router-link>
       </div>
     </slot>
   </nav>
@@ -26,5 +27,9 @@ export default {
 .navbar-nav { float: right; }
 .homeLink { text-decoration: none; color: inherit; }
 .homeLink:hover { text-decoration: none; color: inherit; }
-#logo { max-height: 30px !important; }
+>>> #logo {
+  width: 100px;
+  height: auto;
+  max-height: none;
+}
 </style>

--- a/src/views/Labeler.vue
+++ b/src/views/Labeler.vue
@@ -422,8 +422,8 @@ export default {
 };
 </script>
 
-<style>
-svg {
+<style scoped>
+#plotBox svg {
   font: 10px sans-serif;
   display: block;
   position: absolute;
@@ -579,7 +579,9 @@ kbd {
 }
 
 #logo {
-  max-height: 30px;
+  width: 100px;
+  height: auto;
+  max-height: none;
 }
 </style>
 


### PR DESCRIPTION
## Summary
- add router link for **Upload Data** in navbar
- restrict labeler global SVG rules to its container and size the logo smaller

## Testing
- `npm run lint` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68429d425dac833297e2135d6fe33d57